### PR TITLE
Repeating insult command #7 fixed

### DIFF
--- a/commands/insult.js
+++ b/commands/insult.js
@@ -1,17 +1,31 @@
 const grabInsult = require("../botFunctions/insult");
 
+// using setTimeout to prevent repeating insults.
+// Since await only uses promises
+// we need to wrap setTimeout in a promise
+const setTimeoutPromise = (timeout) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+
+// reply to message if there is only one arg
 module.exports = {
   name: "insult",
   description: "Sends insults",
   async execute(msg, args) {
-    // reply to message if there is only one arg
-    if(args.length===0) {
-      const reply = await grabInsult();
-      msg.reply(reply.toString());      
-    }
     
+    //setting timeout to 2000ms
+    await setTimeoutPromise(2000);
+    if (args.length === 0) {
+      const reply = await grabInsult();
+      msg.reply(reply.toString());
+    }
+
     // else loop over args and send insults
     for (let i = 0; i < args.length; i++) {
+
+      //setting timeout to 2500ms
+      await setTimeoutPromise(2500);
       const reply = await grabInsult();
       msg.channel.send(reply.toString() + args[i]);
     }


### PR DESCRIPTION
Used `setTimeout`  Method and wrapped it in a `promise` since `await` only works for `promises`. 
Now multiple users can be tagged and different results will be relayed.

![insults](https://user-images.githubusercontent.com/78155861/135763383-b259f76a-b3d3-40b7-aae7-666b27ff927e.png)
